### PR TITLE
Support incremental builds

### DIFF
--- a/lib/jekyll/brotli.rb
+++ b/lib/jekyll/brotli.rb
@@ -19,6 +19,12 @@ Jekyll::Hooks.register :site, :post_write do |site|
   Jekyll::Brotli::Compressor.compress_site(site) if Jekyll.env == 'production'
 end
 
+Jekyll::Hooks.register :clean, :on_obsolete do |obsolete|
+  obsolete.delete_if do |path|
+    path.end_with? '.br'
+  end
+end
+
 begin
   require 'jekyll-assets'
 

--- a/lib/jekyll/brotli/compressor.rb
+++ b/lib/jekyll/brotli/compressor.rb
@@ -92,21 +92,13 @@ module Jekyll
 
       # Compresses the file if the site is built incrementally and the
       # source was modified or the compressed file doesn't exist
-      #
-      # We access the cache directly because Jekyll doesn't expect us to
-      # ask twice and always responds false to regenerate?
-      #
-      # @see jekyll/regenerator.rb
       def self.regenerate?(file, site)
-        source_path = if file.is_a? Page
-            site.in_source_dir(file.relative_path)
-          else
-            file.path
-          end
+        orig = file.destination(site.dest)
+        compressed = compressed(orig)
 
-        file_name = compressed(file.destination(site.dest))
+        return true unless File.exist? compressed
 
-        site.regenerator.cache[source_path] || !File.exist?(file_name)
+        File.mtime(orig) > File.mtime(compressed)
       end
     end
   end

--- a/lib/jekyll/brotli/config.rb
+++ b/lib/jekyll/brotli/config.rb
@@ -13,7 +13,8 @@ module Jekyll
         '.stl',
         '.xml',
         '.svg',
-        '.eot'
+        '.eot',
+        '.json'
       ].freeze
     }.freeze
   end


### PR DESCRIPTION
Avoid compressing files when they don't need to by checking Jekyll's regeneration cache and keeping .br files from the site to prevent cleaning.