### PR TITLE
Configurable compression quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ brotli:
     - '.js
 ```
 
+#### Compression quality
+
+By default, `Jekyll::Brotli` uses the maximum compression quality
+supported by Brotli, which is 11.  You can supply your own compression
+quality by setting a number between 0 and 11 on `_config.yml`.
+
+```yml
+brotli:
+  quality: 9
+```
+
 ### Serving pre-compiled gzip files
 
 You will likely need to adjust your web server config to serve these precomputed gzip files. See below for common server configurations:

--- a/lib/jekyll/brotli/compressor.rb
+++ b/lib/jekyll/brotli/compressor.rb
@@ -24,12 +24,15 @@ module Jekyll
       #
       # @return void
       def self.compress_site(site)
+        quality = compression_quality(site)
+
         site.each_site_file do |file|
           next unless regenerate? file.destination(site.dest), site
 
           compress_file(
             file.destination(site.dest),
-            compressable_extensions(site)
+            compressable_extensions(site),
+            quality
           )
         end
       end

--- a/lib/jekyll/brotli/compressor.rb
+++ b/lib/jekyll/brotli/compressor.rb
@@ -50,10 +50,11 @@ module Jekyll
       def self.compress_directory(dir, site)
         extensions = compressable_extensions(site).join(',')
         files = Dir.glob(File.join(dir, "**", "*{#{extensions}}"))
+        quality = compression_quality(site)
         files.each do |file|
           next unless regenerate? file, site
 
-          compress_file(file, compressable_extensions(site))
+          compress_file(file, compressable_extensions(site), quality)
         end
       end
 
@@ -71,10 +72,10 @@ module Jekyll
       #    compressed.
       #
       # @return void
-      def self.compress_file(file_name, extensions)
+      def self.compress_file(file_name, extensions, quality = 11)
         return unless extensions.include?(File.extname(file_name))
         compressed = compressed(file_name)
-        contents = ::Brotli.deflate(File.read(file_name), quality: 11)
+        contents = ::Brotli.deflate(File.read(file_name), quality: quality)
 
         Jekyll.logger.debug "Brotli: #{compressed}"
 
@@ -92,6 +93,10 @@ module Jekyll
 
       def self.compressable_extensions(site)
         site.config.dig("brotli", "extensions") || Jekyll::Brotli::DEFAULT_CONFIG.fetch("extensions")
+      end
+
+      def self.compression_quality(site)
+        site.config.dig("brotli", "quality") || Jekyll::Brotli::DEFAULT_CONFIG.fetch("quality")
       end
 
       # Compresses the file if the site is built incrementally and the

--- a/lib/jekyll/brotli/config.rb
+++ b/lib/jekyll/brotli/config.rb
@@ -3,6 +3,7 @@
 module Jekyll
   module Brotli
     DEFAULT_CONFIG = {
+      'quality' => 11,
       'extensions' => [
         '.html',
         '.css',


### PR DESCRIPTION
Defaults to 11, but could be anything starting from 0.

Not sure how to test it.

We have some big JSON files and the highest compression level takes several minutes for some extra 200KB compression.