### PR TITLE
Support .jsonld files

### DIFF
--- a/lib/jekyll/brotli/config.rb
+++ b/lib/jekyll/brotli/config.rb
@@ -9,6 +9,7 @@ module Jekyll
         '.css',
         '.js',
         '.json',
+        '.jsonld',
         '.txt',
         '.ttf',
         '.atom',


### PR DESCRIPTION
We're working on an ActivityPub plugin for Jekyll and activities are stored as .jsonld files :)